### PR TITLE
Fixed yml syntax

### DIFF
--- a/docker-compose-traefik.yml
+++ b/docker-compose-traefik.yml
@@ -112,7 +112,7 @@ services:
       - "traefik.frontend.headers.frameDeny=true"
 
 # phpMyAdmin - WebUI for MariaDB
-phpmyadmin:
+  phpmyadmin:
     hostname: phpmyadmin
     container_name: phpmyadmin
     image: phpmyadmin/phpmyadmin


### PR DESCRIPTION
At line 115 there was no space at the beginning
ERROR: yaml.parser.ParserError: while parsing a block mapping
  in "./docker-compose.yml", line 1, column 1
expected <block end>, but found '<block mapping start>'