### PR TITLE
Add front end basic auth

### DIFF
--- a/docker-compose-traefik.yml
+++ b/docker-compose-traefik.yml
@@ -31,6 +31,7 @@ services:
 #      - "traefik.frontend.rule=Host:${DOMAINNAME}; PathPrefixStrip: /traefik"
       - "traefik.port=8080"
       - "traefik.docker.network=traefik_proxy"
+      - "traefik.frontend.auth.basic.usersFile=/shared/.htpasswd"
       - "traefik.frontend.headers.SSLRedirect=true"
       - "traefik.frontend.headers.STSSeconds=315360000"
       - "traefik.frontend.headers.browserXSSFilter=true"


### PR DESCRIPTION
Adding basic auth to the front end web interface using the existing .htpasswd setup during the guide. This method only affects the Traefik docker. This method can also be used in other docker containers that do not provide native login access.