### PR TITLE
Correct NextCloud Frame Option

### DIFF
--- a/docker-compose-traefik.yml
+++ b/docker-compose-traefik.yml
@@ -676,8 +676,8 @@ phpmyadmin:
       - "traefik.frontend.headers.SSLHost=example.com"
       - "traefik.frontend.headers.STSIncludeSubdomains=true"
       - "traefik.frontend.headers.STSPreload=true"
-      - "traefik.frontend.headers.frameDeny=true"
-
+#      - "traefik.frontend.headers.frameDeny=true"
+      - "traefik.frontend.headers.CustomFrameOptionsValue=SAMEORIGIN"
 networks:
   traefik_proxy:
     external:


### PR DESCRIPTION
traefik.frontend.headers.frameDeny=true sets the X-Frame-Options to DENY. NextCloud needs X-Frame-Options to SAMEORIGIN. Commented framedeny and added the SAMEORGIN setting.